### PR TITLE
Refactor grammar and improve HTML highlighting

### DIFF
--- a/grammars/language-eml.cson
+++ b/grammars/language-eml.cson
@@ -1,119 +1,202 @@
-# CoffeeScript Object Notation (CSON)
-{
-  'scopeName': 'text.eml.basic'
-  'name': 'Email (EML)'
-  'fileTypes': ['eml', 'msg', 'mbx', 'mbox']
-  'patterns': [
-    # Email addresses
-    {
-      'match': '(\S|<)"[a-zA-Z0-9. \+\_\-]+"\s*&lt;[a-zA-Z0-9.\-]+\@[a-zA-Z0-9.\-]+&gt;(\S|>)',
-      'name': 'variable.other.eml'
-    },
-    {
-      'match': '(\S|<)[a-zZ-Z0-9.\+\_\-]*\s*&lt;[a-zA-Z0-9.\-]+\@[a-zA-Z0-9.\-]+&gt;(\S|>)',
-      'name': 'variable.other.eml'
-    },
-    {
-      'match': '(|<)[a-zA-Z0-9.\+\_\-]+\@[a-zA-Z0-9.\-]+(>|)',
-      'name': 'variable.other.eml'
-    },
+scopeName: 'text.eml.basic'
+name: 'Email (EML)'
+fileTypes: ['eml', 'msg', 'mbx', 'mbox']
+patterns: [
+  {include: "#addresses"}
+  {include: "#headers"}
+  {include: "#encodedWord"}
+  {include: "#specials"}
+  {include: "#uuid"}
+  {include: "#base64"}
+  {include: "#html"}
+  {include: "#quote"}
+  {include: "#ipv4"}
+  {include: "#ipv6"}
+]
 
-    # "Email From" Headers
-    {
-      'match': '^(?i)(envelope-from|return-path|mail-from|from):',
-      'name': 'constant.language.header'
-    },
+repository:
+  
+  # Email addresses
+  addresses:
+    patterns: [
+      {
+        # "John Doe" <john.doe@example.com>
+        name: 'meta.email-address.eml'
+        match: """(?x)
+          ((") [-a-zA-Z0-9.\\x20+_]+ (")) \\s*
+          ((<) [-a-zA-Z0-9.]+@[-a-zA-Z0-9.]+ (>))
+        """
+        captures:
+          1: name: "string.quoted.double.author-name.eml"
+          2: name: "punctuation.definition.string.begin.eml"
+          3: name: "punctuation.definition.string.end.eml"
+          4: name: "constant.other.author-address.eml"
+          5: name: "punctuation.definition.tag.begin.eml"
+          6: name: "punctuation.definition.tag.end.eml"
+      }
+      {
+        # "John Doe" &lt;john.doe@example.com&gt;
+        name: 'meta.email-address.eml'
+        match: """(?x)
+          ((") [-a-zA-Z0-9.\\ +_]+ (")) \\s*
+          ((&lt;) [-a-zA-Z0-9.]+@[-a-zA-Z0-9.]+ (&gt;))
+        """
+        captures:
+          1: name: "string.quoted.double.author-name.eml"
+          2: name: "punctuation.definition.string.begin.eml"
+          3: name: "punctuation.definition.string.end.eml"
+          4: name: "constant.other.author-address.eml"
+          5: name: "punctuation.definition.tag.begin.eml"
+          6: name: "punctuation.definition.tag.end.eml"
+      }
+      {
+        # John <john.doe@example.com>
+        name: 'meta.email-address.eml'
+        match: """(?x)
+          ([-a-zZ-Z0-9.+_]+) \\s*
+          (<)([-a-zA-Z0-9.]+@[-a-zA-Z0-9.]+)(>)
+        """
+        captures:
+          1: name: "string.unquoted.author-name.eml"
+          2: name: "punctuation.definition.tag.begin.eml"
+          3: name: "constant.other.author-address.eml"
+          4: name: "punctuation.definition.tag.end.eml"
+      }
+      {
+        # John &lt;john.doe@example.com&gt;
+        name: 'meta.email-address.eml'
+        match: """(?x)
+          ([-a-zZ-Z0-9.+_]+) \\s*
+          (&lt;)([-a-zA-Z0-9.]+@[-a-zA-Z0-9.]+)(&gt;)
+        """
+        captures:
+          1: name: "string.unquoted.author-name.eml"
+          2: name: "punctuation.definition.tag.begin.eml"
+          3: name: "constant.other.author-address.eml"
+          4: name: "punctuation.definition.tag.end.eml"
+      }
+      {
+        # &lt;john.doe@example.com&gt;
+        match: '(&lt;)([-a-zA-Z0-9.+_]+@[-a-zA-Z0-9.]+)(&gt;)'
+        captures:
+          1: name: "punctuation.definition.tag.begin.eml"
+          2: name: "constant.other.author-address.eml"
+          3: name: "punctuation.definition.tag.end.eml"
+      }
+      {
+        # <john.doe@example.com>
+        match: '(<)([-a-zA-Z0-9.+_]+@[-a-zA-Z0-9.]+)(>)'
+        captures:
+          1: name: "punctuation.definition.tag.begin.eml"
+          2: name: "constant.other.author-address.eml"
+          3: name: "punctuation.definition.tag.end.eml"
+      }
+    ]
 
-    # Required headers
-    {
-      'match': '^(?i)(from|date|to|subject|cc|content-type|precedence|message-id|in-reply-to|references|reply-to|sender|archived-at|x-cmae-virus|\d*zendesk\d*):',
-      'name': 'constant.language.header'
-    },
+  # Content-Transfer-Encoding: base64
+  base64:
+    name: 'text.eml.encoded'
+    match: """(?x) ^
+      (?:[A-Za-z0-9+/]{4})+
+      (?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$
+    """
 
-    # Headers
-    {
-      'match': '^[A-Z][a-zA-Z0-9-]*:',
-      'name': 'constant.language.eml'
-    },
 
-    # Resent Headers
-    {
-      'match': '^.*(?i)resent-.*?:',
-      'name': 'constant.other.eml'
-    },
+  # Header fields
+  headers:
+    captures:
+      1: name: "variable.header.name.eml"
+      2: name: "punctuation.separator.dictionary.key-value.colon.eml"
+    match: """(?xi) ^
+      ( archived-at
+      | cc
+      | content-type
+      | date
+      | envelope-from
+      | from
+      | in-reply-to
+      | mail-from
+      | message-id
+      | precedence
+      | references
+      | reply-to
+      | return-path
+      | sender
+      | subject
+      | to
+      | x-cmae-virus
+      | \\d*zendesk\\d*
+      | [^:]*resent-[^:]*
+      | x-[^:]*
+      | [A-Z][a-zA-Z0-9-]*
+      ) (:)
+    """
 
-    # X-Headers
-    {
-      'match': '^(?i)x-.*?:',
-      'name': 'constant.other.eml'
-    },
+  # Encoded-words (https://www.ietf.org/rfc/rfc2047.txt)
+  encodedWord:
+    name: 'keyword.control.encoded-word.eml'
+    match: '(?i)=\\?utf-8\\?B\\?(.*)\\?='
 
-    # Headers with encoded-words (https://www.ietf.org/rfc/rfc2047.txt)
-    {
-      'match': '(?i)=\?utf-8\?B\?(.*)\?=',
-      'name': 'keyword.control.eml'
-    },
+  # Content-Type: text/html;
+  html:
+    name:  "meta.embedded.html.eml"
+    begin: "(?i)^(?=<html[\\s>])"
+    end:   "(?<=</html>)"
+    patterns: [include: 'text.html.basic']
 
-    # Specials
-    {
-      'match': '(?i)base64',
-      'name': 'variable.eml'
-    },
-    {
-      'match': '(?i)multipart\/.*:',
-      'name': 'variable.eml'
-    },
-    {
-      'match': '(?i)image\/.*;',
-      'name': 'variable.eml'
-    },
-    {
-      'match': '(?i)text\/.*;',
-      'name': 'variable.eml'
-    },
-    {
-      'match': 'boundary=.*',
-      'name': 'keyword.control.eml'
-    },
-    {
-      'match': '^--(?!>).*',
-      'name': 'keyword.control.eml'
-    },
+  # IPv4
+  ipv4:
+    name: 'variable.other.ipv4.eml'
+    match: "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
 
-    # UUID
-    {
-      'match': "(?x)([0-9a-fA-F]{32}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})",
-      'name': 'constant.other.eml'
-    },
+  # IPv6
+  ipv6:
+    name: 'variable.other.eml'
+    match: """(?x)
+      ( ([0-9a-fA-F]{1,4}:){7}     [0-9a-fA-F]{1,4}
+      | ([0-9a-fA-F]{1,4}:){1,7}  :
+      | ([0-9a-fA-F]{1,4}:){1,6}  :[0-9a-fA-F]{1,4}
+      | ([0-9a-fA-F]{1,4}:){1,5} (:[0-9a-fA-F]{1,4}){1,2}
+      | ([0-9a-fA-F]{1,4}:){1,4} (:[0-9a-fA-F]{1,4}){1,3}
+      | ([0-9a-fA-F]{1,4}:){1,3} (:[0-9a-fA-F]{1,4}){1,4}
+      | ([0-9a-fA-F]{1,4}:){1,2} (:[0-9a-fA-F]{1,4}){1,5}
+      | [0-9a-fA-F]{1,4}          :((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)
+      | fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]+
+      | ::(ffff(:0{1,4})?:)? ((25[0-5]|(2[0-4]|1?[0-9])?[0-9])\\.){3}(25[0-5]|(2[0-4]|1?[0-9])?[0-9])
+      | ([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1?[0-9])?[0-9])\\.){3}(25[0-5]|(2[0-4]|1?[0-9])?[0-9])
+      )
+    """
 
-    # Content-Transfer-Encoding: base64
-    {
-      'match': '^(?:[A-Za-z0-9+/]{4})+(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$',
-      'name': 'text.eml.encoded'
-    },
+  # Quoted Text
+  quote:
+    name:  'markup.quote.line.eml'
+    begin: '^[|>]'
+    end:   "$"
+    beginCaptures:
+      0: name: "punctuation.definition.comment.quote.eml"
 
-    # Content-Type: text/html;
-    {
-      'match': '^(?i)<html>(.|\s)*<\/html>$',
-      'include': 'text.html.basic'
-    },
+  # Specials
+  specials:
+    patterns: [{
+      name: 'keyword.operator.special.eml'
+      match: """(?xi)
+        ( base64
+        | multipart\\/.*:
+        | image\\/.*;
+        | text\\/.*
+        | boundary=.*
+        )
+      """
+    },{
+      name: 'keyword.control.eml'
+      match: '^--(?!>).*',
+    }]
 
-    # Quoted Text
-    {
-      'match': '^[|>].*',
-      'name': 'comment.line.eml'
-    },
-
-    # IPv4
-    {
-      'match': "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)",
-      'name': 'variable.other.eml'
-    },
-
-    # IPv6
-    {
-      'match': "(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))",
-      'name': 'variable.other.eml'
-    }
-  ]
-}
+  # UUID
+  uuid:
+    name: 'constant.other.uuid.eml'
+    match: """(?x)
+      ( [0-9a-fA-F]{32}
+      | [0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}
+      )
+    """

--- a/grammars/language-eml.cson
+++ b/grammars/language-eml.cson
@@ -111,44 +111,44 @@ repository:
       0: name: 'keyword.control.boundary.eml'
     patterns: [{
       # Content-Type: text/html;
-      name:  "meta.embedded.html.eml"
-      begin: "^(?i)(Content-Type:)\\s*(text/html(?=[\\s;+]).*)"
-      end:   "^(?=--(?!>))"
+      name:  'meta.embedded.html.eml'
+      begin: '^(?i)(Content-Type:)\\s*(text/html(?=[\\s;+]).*)'
+      end:   '^(?=--(?!>))'
       patterns: [
-        {include: "#boundaryHeaders"}
+        {include: '#boundaryHeaders'}
         {include: 'text.html.basic'}
       ]
-      contentName: "meta.embedded.html"
+      contentName: 'meta.embedded.html'
       beginCaptures:
-        1: patterns: [include: "#headers"]
-        2: patterns: [include: "$self"]
+        1: patterns: [include: '#headers']
+        2: patterns: [include: '$self']
     },{
       # Plain text (no header highlighting)
-      name:  "meta.embedded.text.eml"
-      begin: "^(?i)(Content-Type:)\\s*((?!text/html(?=[\\s;+]))\\S+.*)"
-      end:   "^(?=--(?!>))"
-      contentName: "markup.raw.html"
+      name:  'meta.embedded.text.eml'
+      begin: '^(?i)(Content-Type:)\\s*((?!text/html(?=[\\s;+]))\\S+.*)'
+      end:   '^(?=--(?!>))'
+      contentName: 'markup.raw.html'
       beginCaptures:
-        1: patterns: [include: "#headers"]
-        2: patterns: [include: "$self"]
-      patterns: [include: "#boundaryHeaders"]
+        1: patterns: [include: '#headers']
+        2: patterns: [include: '$self']
+      patterns: [include: '#boundaryHeaders']
     },{
       # Other headers unrelated to content-type
-      include: "$self"
+      include: '$self'
     }]
 
   # Additional headers following Content-Type, but before body 
   boundaryHeaders:
-    begin: "\\G"
-    end: "^(?=\\s*)$"
-    patterns: [include: "$self"]
+    begin: '\\G'
+    end: '^(?=\\s*)$'
+    patterns: [include: '$self']
 
   # Header fields
   headers:
     captures:
-      1: name: "variable.header.name.eml"
-      2: name: "punctuation.separator.dictionary.key-value.colon.eml"
-    match: """(?xi) ^
+      1: name: 'variable.header.name.eml'
+      2: name: 'punctuation.separator.dictionary.key-value.colon.eml'
+    match: '''(?xi) ^
       ( archived-at
       | cc
       | content-type
@@ -171,7 +171,7 @@ repository:
       | x-[^:]*
       | [A-Z][a-zA-Z0-9-]*
       ) (:)
-    """
+    '''
 
   # Encoded-words (https://www.ietf.org/rfc/rfc2047.txt)
   encodedWord:
@@ -181,12 +181,12 @@ repository:
   # IPv4
   ipv4:
     name: 'variable.other.ipv4.eml'
-    match: "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
+    match: '(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)'
 
   # IPv6
   ipv6:
     name: 'variable.other.eml'
-    match: """(?x)
+    match: '''(?x)
       ( ([0-9a-fA-F]{1,4}:){7}     [0-9a-fA-F]{1,4}
       | ([0-9a-fA-F]{1,4}:){1,7}  :
       | ([0-9a-fA-F]{1,4}:){1,6}  :[0-9a-fA-F]{1,4}
@@ -199,33 +199,33 @@ repository:
       | ::(ffff(:0{1,4})?:)? ((25[0-5]|(2[0-4]|1?[0-9])?[0-9])\\.){3}(25[0-5]|(2[0-4]|1?[0-9])?[0-9])
       | ([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1?[0-9])?[0-9])\\.){3}(25[0-5]|(2[0-4]|1?[0-9])?[0-9])
       )
-    """
+    '''
 
   # Quoted Text
   quote:
     name:  'markup.quote.line.eml'
     begin: '^[|>]'
-    end:   "$"
+    end:   '$'
     beginCaptures:
-      0: name: "punctuation.definition.comment.quote.eml"
+      0: name: 'punctuation.definition.comment.quote.eml'
 
   # Specials
   encodingTypes:
     name: 'keyword.operator.special.eml'
-    match: """(?xi)
+    match: '''(?xi)
       ( base64
       | multipart\\/.*:
       | image\\/.*;
       | text\\/.*
       | boundary=.*
       )
-    """
+    '''
 
   # UUID
   uuid:
     name: 'constant.other.uuid.eml'
-    match: """(?x)
+    match: '''(?x)
       ( [0-9a-fA-F]{32}
       | [0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}
       )
-    """
+    '''

--- a/grammars/language-eml.cson
+++ b/grammars/language-eml.cson
@@ -4,8 +4,9 @@ fileTypes: ['eml', 'msg', 'mbx', 'mbox']
 patterns: [
   {include: "#addresses"}
   {include: "#headers"}
+  {include: "#boundary"}
   {include: "#encodedWord"}
-  {include: "#specials"}
+  {include: "#encodingTypes"}
   {include: "#uuid"}
   {include: "#base64"}
   {include: "#html"}
@@ -101,6 +102,46 @@ repository:
       (?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$
     """
 
+  # Multipart MIME boundary
+  boundary:
+    name:  'meta.multi-part.chunk.eml'
+    begin: '^(--(?!>).*)'
+    end:   '^(?=\\1)'
+    beginCaptures:
+      0: name: 'keyword.control.boundary.eml'
+    patterns: [{
+      # Content-Type: text/html;
+      name:  "meta.embedded.html.eml"
+      begin: "^(?i)(Content-Type:)\\s*(text/html(?=[\\s;+]).*)"
+      end:   "^(?=--(?!>))"
+      patterns: [
+        {include: "#boundaryHeaders"}
+        {include: 'text.html.basic'}
+      ]
+      contentName: "meta.embedded.html"
+      beginCaptures:
+        1: patterns: [include: "#headers"]
+        2: patterns: [include: "$self"]
+    },{
+      # Plain text (no header highlighting)
+      name:  "meta.embedded.text.eml"
+      begin: "^(?i)(Content-Type:)\\s*((?!text/html(?=[\\s;+]))\\S+.*)"
+      end:   "^(?=--(?!>))"
+      contentName: "markup.raw.html"
+      beginCaptures:
+        1: patterns: [include: "#headers"]
+        2: patterns: [include: "$self"]
+      patterns: [include: "#boundaryHeaders"]
+    },{
+      # Other headers unrelated to content-type
+      include: "$self"
+    }]
+
+  # Additional headers following Content-Type, but before body 
+  boundaryHeaders:
+    begin: "\\G"
+    end: "^(?=\\s*)$"
+    patterns: [include: "$self"]
 
   # Header fields
   headers:
@@ -137,13 +178,6 @@ repository:
     name: 'keyword.control.encoded-word.eml'
     match: '(?i)=\\?utf-8\\?B\\?(.*)\\?='
 
-  # Content-Type: text/html;
-  html:
-    name:  "meta.embedded.html.eml"
-    begin: "(?i)^(?=<html[\\s>])"
-    end:   "(?<=</html>)"
-    patterns: [include: 'text.html.basic']
-
   # IPv4
   ipv4:
     name: 'variable.other.ipv4.eml'
@@ -176,21 +210,16 @@ repository:
       0: name: "punctuation.definition.comment.quote.eml"
 
   # Specials
-  specials:
-    patterns: [{
-      name: 'keyword.operator.special.eml'
-      match: """(?xi)
-        ( base64
-        | multipart\\/.*:
-        | image\\/.*;
-        | text\\/.*
-        | boundary=.*
-        )
-      """
-    },{
-      name: 'keyword.control.eml'
-      match: '^--(?!>).*',
-    }]
+  encodingTypes:
+    name: 'keyword.operator.special.eml'
+    match: """(?xi)
+      ( base64
+      | multipart\\/.*:
+      | image\\/.*;
+      | text\\/.*
+      | boundary=.*
+      )
+    """
 
   # UUID
   uuid:


### PR DESCRIPTION
### Description of the Change

This PR addresses numerous syntax errors brought up in [issue `#15`](https://github.com/mariozaizar/language-eml/issues/15#issuecomment-424160911), and improves the accuracy of HTML highlighting by applying it to any region delimited by a `Content-Type: text/html;` boundary (which follows a boundary string like `--rlAQ0sLoqKcX=_?`).

It also suppresses e-mail related highlighting inside `Content-Type: text/plain` regions, which causes jarring-looking colours to pop up in certain words (such as `http:` being erroneously highlighted like a header field if it begins on a line by itself. (such as in `spec/fixtures/html_example.eml`, for example).

### Benefits

Sufficiently more accurate highlighting, and several patterns that're currently failing to match will work as intended.

### Possible Drawbacks

None.

### References

Refs: [`#15`](https://github.com/mariozaizar/language-eml/issues/15#issuecomment-424160911)

/cc @pchaigno, @wesinator, @mariozaizar